### PR TITLE
Update LighthouseGeneratorCommand.php

### DIFF
--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -80,7 +80,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
 
             $matching [] = $part;
         }
-        
+
         if ($matching) {
             return implode('\\', $matching);
         } else {

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -22,7 +22,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
 
     protected function rootNamespace()
     {
-        return $this->getDefaultNamespace();
+        return $this->getDefaultNamespace(""); //dummy arg
     }
 
 
@@ -32,7 +32,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
      * @param  string  $rootNamespace
      * @return string
      */
-    protected function getDefaultNamespace($rootNamespace=""): string
+    protected function getDefaultNamespace($rootNamespace): string
     {
         $namespaces = config('lighthouse.namespaces.'.$this->namespaceConfigKey());
 

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -81,9 +81,9 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
             $matching [] = $part;
         }
         
-        if($matching){
+        if ($matching) {
             return implode('\\', $matching);
-        }else{
+        } else {
             return end($namespaces);
         }
     }

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -80,7 +80,11 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
 
             $matching [] = $part;
         }
-
-        return implode('\\', $matching);
+        
+        if($matching){
+            return implode('\\', $matching);
+        }else{
+            return end($namespaces)
+        }
     }
 }

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -84,7 +84,7 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
         if($matching){
             return implode('\\', $matching);
         }else{
-            return end($namespaces)
+            return end($namespaces);
         }
     }
 }

--- a/src/Console/LighthouseGeneratorCommand.php
+++ b/src/Console/LighthouseGeneratorCommand.php
@@ -20,13 +20,19 @@ abstract class LighthouseGeneratorCommand extends GeneratorCommand
         return ucfirst(trim($this->argument('name')));
     }
 
+    protected function rootNamespace()
+    {
+        return $this->getDefaultNamespace();
+    }
+
+
     /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace
      * @return string
      */
-    protected function getDefaultNamespace($rootNamespace): string
+    protected function getDefaultNamespace($rootNamespace=""): string
     {
         $namespaces = config('lighthouse.namespaces.'.$this->namespaceConfigKey());
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

ref #1236

**Changes**

When `$matching` is empty, command get infinit loop, and failed.

add `return end($namespaces) ` for fallback when `$matching` is empty.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here.
Make sure to mention them in UPGRADE.md. -->
